### PR TITLE
fix(retry): let exponentialBackoff and shouldCheckMaxInRow compose

### DIFF
--- a/src/main/java/io/github/mahdibohloul/projectreactor/retry/aop/annotation/AnnotationAwareReactiveRetryOperationsInterceptor.java
+++ b/src/main/java/io/github/mahdibohloul/projectreactor/retry/aop/annotation/AnnotationAwareReactiveRetryOperationsInterceptor.java
@@ -105,8 +105,8 @@ public class AnnotationAwareReactiveRetryOperationsInterceptor implements Introd
 	private MethodInterceptor getBackOffInterceptor(Object target, Method method, ReactiveRetryable reactiveRetryable) {
 		return ReactiveRetryInterceptorBuilder.backOff().setBackOffFactor(reactiveRetryable.backOffFactor())
 				.setMaxDelay(reactiveRetryable.backOffMaxDelay()).setMinDelay(reactiveRetryable.backOffMinDelay())
-				.setExclude(reactiveRetryable.exclude()).setInclude(reactiveRetryable.include())
-				.setMaxAttempts(reactiveRetryable.maxAttempts()).build();
+				.setShouldCheckMaxInRow(reactiveRetryable.shouldCheckMaxInRow()).setExclude(reactiveRetryable.exclude())
+				.setInclude(reactiveRetryable.include()).setMaxAttempts(reactiveRetryable.maxAttempts()).build();
 	}
 
 	private <A extends Annotation> A findAnnotationOnTarget(Object target, Method method, Class<A> annotation) {

--- a/src/main/java/io/github/mahdibohloul/projectreactor/retry/aop/annotation/ReactiveRetryable.java
+++ b/src/main/java/io/github/mahdibohloul/projectreactor/retry/aop/annotation/ReactiveRetryable.java
@@ -77,7 +77,21 @@ public @interface ReactiveRetryable {
 	boolean exponentialBackoff() default false;
 
 	/**
-	 * Whether the maximum number of attempts in a row should be checked.
+	 * Whether {@link #maxAttempts()} counts <em>consecutive</em> failures rather
+	 * than failures over the lifetime of the subscription.
+	 *
+	 * <p>
+	 * Composes with {@link #exponentialBackoff()}: setting both gives "at most
+	 * {@code maxAttempts} failures in a row, with exponential backoff between
+	 * them".
+	 *
+	 * <p>
+	 * <strong>Note</strong> that the attempt counter is reset by <em>emitted
+	 * elements</em>. A method returning a source that never emits -- a
+	 * {@code Mono<Void>}, or a long-lived loop that only signals completion or
+	 * error -- has nothing to reset on, so {@code maxAttempts} stays an effective
+	 * lifetime budget for it regardless of this flag. Such methods want an
+	 * unbounded {@code maxAttempts} instead.
 	 *
 	 * @return Whether the maximum number of attempts in a row should be checked.
 	 */

--- a/src/main/java/io/github/mahdibohloul/projectreactor/retry/aop/interceptor/ReactiveRetryInterceptorBuilder.java
+++ b/src/main/java/io/github/mahdibohloul/projectreactor/retry/aop/interceptor/ReactiveRetryInterceptorBuilder.java
@@ -269,11 +269,12 @@ public abstract class ReactiveRetryInterceptorBuilder<T extends MethodIntercepto
 		private long minDelay = -1;
 		private long maxDelay = -1;
 		private double backOffFactor = -1.0;
+		private boolean shouldCheckMaxInRow = false;
 
 		@Override
 		public BackOffReactiveRetryInterceptor build() {
 			RetryBackoffSpec retryBackoffSpec = Retry.backoff(this.maxAttempts, Duration.ofMillis(100))
-					.filter(this::errorFilter)
+					.transientErrors(this.shouldCheckMaxInRow).filter(this::errorFilter)
 					.doBeforeRetry(retrySignal -> log.error(DEFAULT_BEFORE_RETRYING_ERROR_MESSAGE,
 							retrySignal.totalRetries(), retrySignal.failure()))
 					.doAfterRetry(retrySignal -> log.error(DEFAULT_AFTER_RETRYING_ERROR_MESSAGE,
@@ -301,6 +302,34 @@ public abstract class ReactiveRetryInterceptorBuilder<T extends MethodIntercepto
 
 		public BackOffRetryInterceptorBuilder setBackOffFactor(double backOffFactor) {
 			this.backOffFactor = backOffFactor;
+			return this;
+		}
+
+		/**
+		 * Makes {@code maxAttempts} count <em>consecutive</em> failures rather than
+		 * failures over the lifetime of the subscription, while keeping the exponential
+		 * backoff.
+		 *
+		 * <p>
+		 * This is what {@link Retry#maxInARow(long)} provides for a plain
+		 * {@link RetrySpec}, and {@link RetryBackoffSpec#transientErrors(boolean)} is
+		 * its equivalent here: the retry counter is reset every time the source emits
+		 * an element, so a source that recovers starts again from a full budget.
+		 *
+		 * <p>
+		 * <strong>Note</strong> that the reset is driven by <em>emitted elements</em>.
+		 * A source that never emits -- a {@code Mono<Void>}, or a long-lived loop that
+		 * only signals completion or error -- has nothing to reset on, so
+		 * {@code maxAttempts} remains an effective lifetime budget for it no matter
+		 * what this flag is set to. Such call sites want an unbounded
+		 * {@code maxAttempts}, not this flag.
+		 *
+		 * @param shouldCheckMaxInRow
+		 *            whether {@code maxAttempts} counts consecutive failures.
+		 * @return the builder
+		 */
+		public BackOffRetryInterceptorBuilder setShouldCheckMaxInRow(boolean shouldCheckMaxInRow) {
+			this.shouldCheckMaxInRow = shouldCheckMaxInRow;
 			return this;
 		}
 

--- a/src/test/java/io/github/mahdibohloul/projectreactor/retry/aop/ApplicationTests.java
+++ b/src/test/java/io/github/mahdibohloul/projectreactor/retry/aop/ApplicationTests.java
@@ -8,6 +8,7 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public class ApplicationTests {
@@ -59,6 +60,11 @@ public class ApplicationTests {
 		@Bean
 		public CustomInterceptorService customInterceptorService() {
 			return new CustomInterceptorService();
+		}
+
+		@Bean
+		public TransientErrorsBackOffService transientErrorsBackOffService() {
+			return new TransientErrorsBackOffService();
 		}
 	}
 
@@ -176,6 +182,45 @@ public class ApplicationTests {
 
 		public int getCount() {
 			return count;
+		}
+	}
+
+	/**
+	 * Exercises {@code exponentialBackoff} and {@code shouldCheckMaxInRow}
+	 * together. Both methods carry the same budget of two consecutive failures;
+	 * they differ only in whether the source emits anything, which is what resets
+	 * the counter.
+	 */
+	public static class TransientErrorsBackOffService {
+		private int subscriptions = 0;
+
+		/**
+		 * Emits an element before each failure, so the attempt counter is reset every
+		 * time and three failures are survived on a budget of two consecutive ones.
+		 */
+		@ReactiveRetryable(exponentialBackoff = true, maxAttempts = 2, shouldCheckMaxInRow = true, backOffMinDelay = 1)
+		public Flux<String> emitThenFail() {
+			return Flux.defer(() -> {
+				if (++this.subscriptions <= 3)
+					return Flux.just("value").concatWith(Flux.error(new RuntimeException("error")));
+				return Flux.just("value");
+			});
+		}
+
+		/**
+		 * Never emits, so nothing resets the counter and the same budget behaves as a
+		 * lifetime one.
+		 */
+		@ReactiveRetryable(exponentialBackoff = true, maxAttempts = 2, shouldCheckMaxInRow = true, backOffMinDelay = 1)
+		public Flux<String> failWithoutEmitting() {
+			return Flux.defer(() -> {
+				this.subscriptions++;
+				return Flux.error(new RuntimeException("error"));
+			});
+		}
+
+		public int getSubscriptions() {
+			return subscriptions;
 		}
 	}
 

--- a/src/test/java/io/github/mahdibohloul/projectreactor/retry/aop/annotation/EnableReactiveRetryTests.java
+++ b/src/test/java/io/github/mahdibohloul/projectreactor/retry/aop/annotation/EnableReactiveRetryTests.java
@@ -35,6 +35,32 @@ class EnableReactiveRetryTests {
 	}
 
 	@Test
+	void backOffComposesWithMaxInRow() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				ApplicationTests.TestConfiguration.class);
+		ApplicationTests.TransientErrorsBackOffService service = context
+				.getBean(ApplicationTests.TransientErrorsBackOffService.class);
+		// Three failures on a budget of two, survived because each is preceded by an
+		// emission that resets the in-a-row counter.
+		StepVerifier.create(service.emitThenFail()).expectNext("value", "value", "value", "value").verifyComplete();
+		Assertions.assertEquals(4, service.getSubscriptions());
+		context.close();
+	}
+
+	@Test
+	void backOffWithMaxInRowStillExhaustsWithoutEmissions() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				ApplicationTests.TestConfiguration.class);
+		ApplicationTests.TransientErrorsBackOffService service = context
+				.getBean(ApplicationTests.TransientErrorsBackOffService.class);
+		// Nothing ever resets the counter, so the budget is spent over the lifetime of
+		// the subscription: the initial attempt plus two retries.
+		StepVerifier.create(service.failWithoutEmitting()).expectError(RuntimeException.class).verify();
+		Assertions.assertEquals(3, service.getSubscriptions());
+		context.close();
+	}
+
+	@Test
 	void withoutRetryApplication() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
 				ApplicationTests.WithoutRetryConfiguration.class);


### PR DESCRIPTION
## The bug

`exponentialBackoff` and `shouldCheckMaxInRow` cannot both take effect, and the annotation gives no hint of it.

The two builders produce incompatible spec types:

- `MaxInRowRetryInterceptorBuilder` → `Retry.maxInARow(maxAttempts)` — a `RetrySpec`, **no backoff**
- `BackOffRetryInterceptorBuilder` → `Retry.backoff(maxAttempts, …)` — a `RetryBackoffSpec`, **no in-a-row semantics**

So they are mutually exclusive *by construction*, and `AnnotationAwareReactiveRetryOperationsInterceptor.getDelegate` has no choice but to drop one. Its branch order is `interceptor()` → `exponentialBackoff()` → `shouldCheckMaxInRow()` → `backOffFixDelay()`, so backoff wins and **`shouldCheckMaxInRow` is silently ignored**.

The consequence is not cosmetic. Every call site setting both gets a **lifetime** attempt budget while the annotation reads as consecutive-failure. For a long-lived subscription — a Kafka receive loop, a stream processor — that means `maxAttempts = 10` is ten failures across the entire uptime of the process, after which the subscription terminates for good. We found this the hard way.

## The fix

Reactor already models the combination: `RetryBackoffSpec.transientErrors(true)` *is* "maxAttempts in a row, with backoff" — it resets the counter whenever the source emits. So the flag is threaded into `BackOffRetryInterceptorBuilder`:

```java
RetryBackoffSpec retryBackoffSpec = Retry.backoff(this.maxAttempts, Duration.ofMillis(100))
        .transientErrors(this.shouldCheckMaxInRow)
        .filter(this::errorFilter)
        ...
```

plus a `setShouldCheckMaxInRow` on the builder and the pass-through in `getBackOffInterceptor`.

**The branch order in `getDelegate` is deliberately unchanged.** Reordering it would alter behaviour for every existing call site that sets one flag — exactly the class of silent surprise this PR exists to remove. Call sites setting a single flag behave identically to before.

## Two caveats, documented on the annotation

Both surprised us in production, so they are in the Javadoc rather than only in this description:

1. **`transientErrors` resets on emitted *elements*.** A method returning `Mono<Void>`, or any long-lived source that only ever signals completion or error, has nothing to reset on — so `maxAttempts` remains an effective lifetime budget for it no matter what the flag says. Those call sites want an unbounded `maxAttempts`, not this flag. This is worth being loud about: it means fixing the library does **not** make `maxAttempts = 10, shouldCheckMaxInRow = true` safe for a never-emitting source, and anyone "restoring intent" at such a call site after upgrading would reintroduce the original bug.

2. **`backOffFixDelay` + `shouldCheckMaxInRow` still collide** the same way — the `maxInRow` branch is tested first and the fixed delay is dropped. Fixing that needs the branch reorder above, so it is left alone here and noted as a known remaining case.

## Tests

Two new cases, and they discriminate — I verified the first **fails** with `.transientErrors(...)` removed:

- `backOffComposesWithMaxInRow` — three failures survived on a budget of two, because each is preceded by an emission that resets the counter.
- `backOffWithMaxInRowStillExhaustsWithoutEmissions` — the same budget on a source that never emits still exhausts after the initial attempt plus two retries, pinning caveat 1.

## Blast radius

Any `@ReactiveRetryable` anywhere that sets both flags currently has a silently-wrong budget, and will change behaviour on upgrade — in the direction the author originally intended. Worth a grep before rolling out.

Note `./gradlew bootJar` fails on this branch, but it fails identically on `master` (no main class in a library project); unrelated to this change. `test` and `spotlessCheck` are green.
